### PR TITLE
Update the list of Java dependencies

### DIFF
--- a/cpp/jvm_wrapper_unix.cpp
+++ b/cpp/jvm_wrapper_unix.cpp
@@ -49,7 +49,7 @@ static std::vector<std::string> dependencies =
   "poi-ooxml-lite.jar", "protobuf-java.jar",
   "protobuf-java-util.jar", "REDapp_Lib.jar",
   "SparseBitSet.jar", "weather.jar", "wtime.jar",
-  "xml-apis.jar", "xmlbeans.jar" };
+  "xmlbeans.jar" };
 
 
 class NativeJVM_Unix : public NativeJVM {

--- a/cpp/jvm_wrapper_win.cpp
+++ b/cpp/jvm_wrapper_win.cpp
@@ -95,7 +95,7 @@ static std::vector<std::string> dependencies =
   "poi-ooxml-lite.jar", "protobuf-java.jar",
   "protobuf-java-util.jar", "REDapp_Lib.jar",
   "SparseBitSet.jar", "weather.jar", "wtime.jar",
-  "xml-apis.jar", "xmlbeans.jar" };
+  "xmlbeans.jar" };
 
 
 class NativeJVM_Win : public NativeJVM {


### PR DESCRIPTION
One of the Java dependencies is not needed for what the Java libraries are used for and is inconsistently downloaded by Maven.